### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,15 +10,15 @@ For below image this doesn't work, unfortunately, because GitHub downloads the i
 
 ![Live countdown to new year](http://only-media.nl/gif/gif.php)
 
-##Note
+## Note
 I received some questions about Gmail so lets describe this mail client a bit more in detail. This script is successfully tested with Gmail, at the moment of writing, which is *2015-12-23*. Gmail loads the images via their own proxy, so not directly from source. There are different opinions about the proxy, but it seems that Google's proxy protects your private data and only informs the sender that the email has been opened. There are speculations that Gmail caches the images, but still respect the cache headers, so you can instruct Gmail how often to refresh the data. I personally had no trouble with the cache whatsoever! I've tested this countdown image numerous times in Gmail and of course you can test it yourself as well. Just to be sure I've added some cache disabling headers in the examples.
 
-##Composer Installation
+## Composer Installation
 1. Get Composer
 2. Require php-gif with `php composer.phar require erikvdven/php-gif`
 3. Add the following to your application's main PHP file: `require 'vendor/autoload.php';`
 
-##Getting Started
+## Getting Started
 
 Create a PHP file and add these headers at the beginning of the file:
 ```php
@@ -63,7 +63,7 @@ Finally you generate the image and `echo` the results on the screen:
 echo $gif->generate($imageFrames);
 ```
 
-##Example
+## Example
 
 A more complete example. You could copy/paste below code to a file and execute it in the browser to view a more complete result. As you can see it's not required to use text in your GIF image and you can add as much text per frame, and as much frames per GIF image as you like.
 
@@ -137,10 +137,10 @@ echo $gif->generate($imageFrames);
 ?>
 ```
 
-##License & Credits
+## License & Credits
 
 This software is published under the [MIT License](https://en.wikipedia.org/wiki/MIT_License).
 
-######GIFEncoder
+###### GIFEncoder
 
 GIFEncoder.class.php contains minor adaptations from the GIFEncoder PHP class by [László Zsidi](http://gifs.hu).


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
