### PR TITLE
Fix broken example

### DIFF
--- a/examples/countdown/countdown.php
+++ b/examples/countdown/countdown.php
@@ -32,9 +32,9 @@ for ($i=1; $i<20; $i++){
 	);
 
 	$textDefaults = array(
-					'font-size' => 24,
+					'fonts-size' => 24,
 					'angle' => 0,
-					'font-color' => '#000',
+					'fonts-color' => '#000',
 					'y-position' => 130
 					);
 

--- a/src/Gif/GIFGenerator.php
+++ b/src/Gif/GIFGenerator.php
@@ -114,7 +114,7 @@ Class GIFGenerator {
 			$image = $this->_createImage($frame['image']);
 			
 			if(array_key_exists('text', $frame))
-				foreach($frame['text'] as $text) {
+				foreach($frame['text'] as $key => $text) {
 
                     // Set defaults
                     $defaults = array(


### PR DESCRIPTION
In the example every frame has an array of day, hour, minute, and second as keys of the array. This pull request allows keys to exist for multiple text items per frame and fixes the properties of the example